### PR TITLE
Update vim-tmux-runner.txt

### DIFF
--- a/doc/vim-tmux-runner.txt
+++ b/doc/vim-tmux-runner.txt
@@ -9,7 +9,7 @@ CONTENTS                                                        *vtr-contents*
       1. About............................ |VTR-About|
       2. Usage ........................... |VTR-Usage|
         2.1  ............................... |VtrSendCommandToRunner|
-        2.2  ............................... |VtrSendLineToRunner|
+        2.2  ............................... |VtrSendLinesToRunner|
         2.3  ............................... |VtrSendSelectedToRunner|
         2.4  ............................... |VtrOpenRunner|
         2.5  ............................... |VtrKillRunner|
@@ -70,7 +70,7 @@ USAGE (2)                                                           *VTR-Usage*
 VTR provides a collection of commands and functions that allow Vim to interact
 with tmux. The primary command is VtrSendCommandToRunner. This allows for any
 command string to be passed to tmux for execution. The commands
-VtrSendLineToRunner and VtrSendSelectedToRunner allow for either the current
+VtrSendLinesToRunner and VtrSendSelectedToRunner allow for either the current
 visually selected region or the current line to be sent to the tmux runner
 pane for execution.  This functionality is similar to SLIME[5] mode for the
 Emacs text editor.
@@ -102,8 +102,8 @@ continue to be used for subsequent calls to the command. The stored command
 can be cleared using |VtrFlushCommand|.
 
 ------------------------------------------------------------------------------
-                                                          *VtrSendLineToRunner*
-2.2 VtrSendLineToRunner~
+                                                          *VtrSendLinesToRunner*
+2.2 VtrSendLinesToRunner~
 
 Send the current line from the Vim buffer to the runner pane for execution.
 
@@ -339,7 +339,7 @@ The following normal mode maps are provided when g:VtrUseVtrMaps is set to 1:
         <leader>rr   |   VtrResizeRunner<cr>
         <leader>ror  |   VtrReorientRunner<cr>
         <leader>sc   |   VtrSendCommandToRunner<cr>
-        <leader>sl   |   VtrSendLineToRunner<cr>
+        <leader>sl   |   VtrSendLinesToRunner<cr>
         <leader>or   |   VtrOpenRunner<cr>
         <leader>kr   |   VtrKillRunner<cr>
         <leader>fr   |   VtrFocusRunner<cr>


### PR DESCRIPTION
## What is the change?
This change modifies the documentation to use the actual existing command `VtrSendLinesToRunner` as opposed to what it says currently in the documentation: `VtrSendLineToRunner`. Notice my change from the singular usage of the word "Line" to the plural "Lines".

## Why this change? 
If you look here you will see the command `VtrSendLineToRunner` doesn't actually exist, so I believe it to be a typo in the plugin documentation.
<img width="665" alt="screen shot 2015-10-17 at 2 08 35 am" src="https://cloud.githubusercontent.com/assets/795646/10557293/0c7f253e-7474-11e5-8e43-83ec051ae07c.png">

Let me know @christoomey if this is not correct. Happy to close this PR if I'm wrong :) 