### PR TITLE
Adding g:VtrBeforeEach to allow ignoring commands in history

### DIFF
--- a/doc/vim-tmux-runner.txt
+++ b/doc/vim-tmux-runner.txt
@@ -21,6 +21,7 @@ CONTENTS                                                        *vtr-contents*
         2.11 ............................... |VtrFlushCommand|
         2.12 ............................... |VtrSendCtrlD|
         2.13 ............................... |VtrSendFile|
+        2.14 ............................... |VtrBeforeEach|
       3. Configuration ................... |VTR-Configuration|
         3.1 ................................ |VtrPercentage|
         3.2 ................................ |VtrOrientation|
@@ -233,6 +234,22 @@ Any settings in your g:vtr_filetype_runner_overrides will take precedence
 over the default values.
 
 This command expects a runner to be attached. Add ! to force a runner.
+
+------------------------------------------------------------------------------
+                                                                *VtrBeforeEach*
+2.14 VtrBeforeEach~
+
+Append something to the beggining of every command sent to the runner.
+A possible use case for this is to prevent your ran commands to be included in
+your history file. For that, set this variable to a single space:
+
+  let g:BeforeEach = " "
+
+And configure your shell's history to ignore commands that begin with a space.
+For instance, in zsh, you can do that with:
+
+  setopt HIST_IGNORE_SPACE
+
 
 ==============================================================================
 CONFIGURATION (3)                                           *VTR-Configuration*

--- a/plugin/vim-tmux-runner.vim
+++ b/plugin/vim-tmux-runner.vim
@@ -171,7 +171,9 @@ function! s:_SendKeys(keys)
 endfunction
 
 function! s:SendKeys(keys)
-    let cmd = g:VtrClearBeforeSend ? g:VtrClearSequence.a:keys : a:keys
+    let clear_cmd = g:VtrClearBeforeSend ? g:VtrClearSequence : ""
+    let before_cmd = shellescape(g:VtrBeforeEach)
+    let cmd = join([clear_cmd, before_cmd, a:keys])
     call s:_SendKeys(cmd)
     call s:SendEnterSequence()
 endfunction
@@ -477,6 +479,7 @@ function! s:InitializeVariables()
     call s:InitVariable("g:VtrOrientation", "v")
     call s:InitVariable("g:VtrInitialCommand", "")
     call s:InitVariable("g:VtrGitCdUpOnOpen", 0)
+    call s:InitVariable("g:VtrBeforeEach", " ")
     call s:InitVariable("g:VtrClearBeforeSend", 1)
     call s:InitVariable("g:VtrPrompt", "Command to run: ")
     call s:InitVariable("g:VtrUseVtrMaps", 0)


### PR DESCRIPTION
See the `doc/vim-tmux-runner.txt` for an explanation

In short, this enables me to prepend a space to every command, and configure my shell to ignore those commands in the history file