### PR TITLE
Add elixir to list of CurrentFiletypeRunners

### DIFF
--- a/doc/vim-tmux-runner.txt
+++ b/doc/vim-tmux-runner.txt
@@ -104,7 +104,7 @@ can be cleared using |VtrFlushCommand|.
                                                           *VtrSendLinesToRunner*
 2.2 VtrSendLinesToRunner~
 
-Send the current line or the current visual selection from the Vim buffer 
+Send the current line or the current visual selection from the Vim buffer
 to the runner pane for execution.
 
 ------------------------------------------------------------------------------
@@ -219,8 +219,8 @@ Send a command to execute the current file as a script. The command will be
 crafted based on the filetype of the current buffer, e.g. for a file "foo.rb"
 (filetype "ruby"), the command would be "ruby {filename}" with {filename}
 populated based on the current file. There are default configurations provided
-for ruby, javascript (via node), python, and sh. You can override and or add
-by defining a dictionary in your Vimrc, e.g.:
+for elixir, javascript (via node), python, ruby, and sh. You can override and
+or add by defining a dictionary in your Vimrc, e.g.:
 
   let g:vtr_filetype_runner_overrides = {
         \ 'ruby': 'ruby -w {file}',

--- a/plugin/vim-tmux-runner.vim
+++ b/plugin/vim-tmux-runner.vim
@@ -419,9 +419,10 @@ endfunction
 
 function! s:CurrentFiletypeRunners()
     let default_runners = {
-            \ 'ruby': 'ruby {file}',
+            \ 'elixir': 'elixir {file}',
             \ 'javascript': 'node {file}',
             \ 'python': 'python {file}',
+            \ 'ruby': 'ruby {file}',
             \ 'sh': 'sh {file}'
             \ }
     if exists("g:vtr_filetype_runner_overrides")


### PR DESCRIPTION
What do you think of adding elixir as a default filetype runner?  I totally understand if you want to leave it to the overrides option to handle.  Also, I alphabetized the list of runners because I wasn't sure where to add elixir.

Thanks for this fantastic plugin.