### PR TITLE
Add bracketed paste option (fixes #65)

### DIFF
--- a/doc/vim-tmux-runner.txt
+++ b/doc/vim-tmux-runner.txt
@@ -460,5 +460,22 @@ line to any multi line send, use the following setting.
 
 Default: 0
 
+------------------------------------------------------------------------------
+                                                             *VtrBracketedPaste*
+
+3.15 g:VtrBracketedPaste
+
+Wrap the text to be sent with the bracketed paste characters \e[200~ and \e[201~,
+so that the terminal doesn't execute anything until all lines have been
+received.
+
+This is especially useful for iPython versions 5+, where otherwise only the
+first line of a selection will be executed.
+
+  let g:VtrBracketedPaste = 1
+
+Default: 0
+
+
 ==============================================================================
 vim:tw=78:ts=2:sw=2:expandtab:ft=help:norl:

--- a/plugin/vim-tmux-runner.vim
+++ b/plugin/vim-tmux-runner.vim
@@ -393,7 +393,10 @@ endfunction
 function! s:SendTextToRunner(lines)
     if !s:ValidRunnerPaneSet() | return | endif
     let prepared = s:PrepareLines(a:lines)
-    let joined_lines = join(prepared, "\r") . "\r"
+    let joined_lines = join(prepared, "\r") . "\r" 
+    if g:VtrBracketedPaste 
+        let joined_lines = "\e[200~" . joined_lines . "\e[201~\n" 
+    endif
     let send_keys_cmd = s:TargetedTmuxCommand("send-keys", s:runner_pane)
     let targeted_cmd = send_keys_cmd . ' ' . shellescape(joined_lines)
     call s:SendTmuxCommand(targeted_cmd)


### PR DESCRIPTION
Add a new configuration setting, VtrBracketedPaste, which wraps the text sent to tmux in the [bracketed paste](https://cirw.in/blog/bracketed-paste) characters. This allows executing multiple lines in iPython 5+.

Signed-off-by: Adam Obeng <github@binaryeagle.com>