### PR TITLE
Allow specifying the pane index with VtrAttachToPane (fixes #67)

### DIFF
--- a/plugin/vim-tmux-runner.vim
+++ b/plugin/vim-tmux-runner.vim
@@ -246,7 +246,12 @@ function! s:AltPane()
   endif
 endfunction
 
-function! s:PromptForRunnerToAttach()
+function! s:PromptForRunnerToAttach(...)
+  let s:pane_index = ''
+  if exists("a:1") && a:1 != ""
+      let s:pane_index = a:1
+  endif
+  if s:pane_index == ''
   if s:PaneCount() == 2
     call s:AttachToPane(s:AltPane())
   else
@@ -259,6 +264,10 @@ function! s:PromptForRunnerToAttach()
     else
       call s:EchoError("No pane specified. Cancelling.")
     endif
+  endif
+  else
+    echom s:pane_index
+    call s:AttachToPane(s:pane_index)
   endif
 endfunction
 
@@ -453,7 +462,7 @@ function! s:DefineCommands()
     command! VtrClearRunner call s:SendClearSequence()
     command! VtrFlushCommand call s:FlushCommand()
     command! VtrSendCtrlD call s:SendCtrlD()
-    command! VtrAttachToPane call s:PromptForRunnerToAttach()
+    command! -bang -nargs=? VtrAttachToPane call s:PromptForRunnerToAttach(<f-args>)
 endfunction
 
 function! s:DefineKeymaps()


### PR DESCRIPTION
Hi Chris,

The usage is as below:
:VtrAttachToPane
will trigger interactive pane management. existing behaviour is retained.

:VtrAttachToPane 1
will attach to the pane number
