### PR TITLE
Update documentation around VtrSendCommandToRunner!

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ VtrSendCommandToRunner
 ```
 
 This command will prompt for a command to run, then send it to the runner pane
-for execution. If one doesn't currently exist, a new runner pane will be
-created. Subsequent calls to `VtrSendCommandToRunner` will reuse the provided
-command.
+for execution. Subsequent calls to `VtrSendCommandToRunner` will reuse the
+provided command.
+
+If you would like VTR to create a runner pane if one doesn't exist while issuing
+a command, a bang version can be used: `VtrSendCommandToRunner!`.
 
 VTR provides configuration options that allow for control over the size and
 location of the VTR runner pane. In addition, VTR provides commands to resize,

--- a/doc/vim-tmux-runner.txt
+++ b/doc/vim-tmux-runner.txt
@@ -89,10 +89,15 @@ environments and it is this ability that give VTR its power.
                                                        *VtrSendCommandToRunner*
 2.1 VtrSendCommandToRunner~
 
-Send a command to the tmux runner pane. This is the primary purpose of VTR. A
-new runner pane will be created. A detached pane will be reattached. By
-default, the runner will be cleared before sending the provided command, but
-this behavior can be disabled with the |VtrClearBeforeSend| setting.
+Send a command to the tmux runner pane. This is the primary purpose of VTR.
+
+Before using this command, attaching to a tmux runner pane via VtrOpenRunner
+or VtrAttachToPane is required. If you would like VTR to create a runner pane
+if it doesn't exist while issuing a command, a bang version can be used:
+VtrSendCommandToRunner!.
+
+By default, the runner will be cleared before sending the provided command,
+but this behavior can be disabled with the |VtrClearBeforeSend| setting.
 
 The first time this command is called, it will prompt for a command to send to
 the runner. The specific prompt text can be configured via the |VtPrompt|


### PR DESCRIPTION
Fixes #80.

Updates the helpfile and README to include information about the bang version of `VtrSendCommandToRunner`.