### PR TITLE
fix: restore AttachToPane call

### DIFF
--- a/plugin/vim-tmux-runner.vim
+++ b/plugin/vim-tmux-runner.vim
@@ -488,7 +488,7 @@ function! s:DefineCommands()
     command! VtrFlushCommand call s:FlushCommand()
     command! VtrSendCtrlD call s:SendCtrlD()
     command! VtrSendCtrlC call s:SendCtrlC()
-    command! VtrAttachToPane call s:PromptForRunnerToAttach()
+    command! -bang -nargs=? -bar VtrAttachToPane call s:AttachToPane(<f-args>)
     command! -nargs=1 VtrSendKeysRaw call s:SendKeysRaw(<q-args>)
 endfunction
 


### PR DESCRIPTION
`VtrAttachToPane` command was accidentally overwritten in #98. This restores the correct command.

Can test out by grabbing the branch with your [package manager](https://github.com/junegunn/vim-plug) of choice:

```
Plug 'tmm/vim-tmux-runner', { 'branch': 'tmm/attach-to-pane' }
```

Then running `:VtrAttachToPane`.