### PR TITLE
Send lines one at a time

### DIFF
--- a/plugin/vim-tmux-runner.vim
+++ b/plugin/vim-tmux-runner.vim
@@ -432,10 +432,11 @@ endfunction
 function! s:SendTextToRunner(lines)
     if !s:ValidRunnerPaneSet() | return | endif
     let prepared = s:PrepareLines(a:lines)
-    let joined_lines = join(prepared, "\r") . "\r"
     let send_keys_cmd = s:TargetedTmuxCommand("send-keys", s:runner_pane)
-    let targeted_cmd = send_keys_cmd . ' ' . shellescape(joined_lines)
-    call s:SendTmuxCommand(targeted_cmd)
+    for line in prepared
+      let targeted_cmd = send_keys_cmd . ' ' . shellescape(line . "\r")
+      call s:SendTmuxCommand(targeted_cmd)
+    endfor
 endfunction
 
 function! s:SendFileViaVtr(ensure_pane)


### PR DESCRIPTION
Previously the VtrSendLinesToRunner command was implemented by joining
the lines together with `\r` newline characters and then sending them
via a single batch `tmux send-keys` call. This caused some REPLs (pry
most notably) to display all the lines at once, and occasionally
mis-handle the sent text.

With this change, each line is now sent via a distinct `tmux send-keys`
call, better approximating a user interacting with the REPL.