### PR TITLE
Add support for automatically re-attaching to the runner pane

### DIFF
--- a/doc/vim-tmux-runner.txt
+++ b/doc/vim-tmux-runner.txt
@@ -39,6 +39,8 @@ CONTENTS                                                        *vtr-contents*
         3.12 ............................... |VtrStripLeadingWhitespace|
         3.13 ............................... |VtrClearEmptyLines|
         3.14 ............................... |VtrAppendNewline|
+        3.15 ............................... |VtrCreatedRunnerPaneName|
+        3.16 ............................... |VtrAutomaticReattachByName|
 
 ==============================================================================
 ABOUT (1)                                                           *VTR-About*
@@ -480,6 +482,32 @@ line might be needed to close the preceding context. To enable appending a new
 line to any multi line send, use the following setting.
 
   let g:VtrAppendNewline = 1
+
+Default: 0
+
+------------------------------------------------------------------------------
+                                                     *VtrCreatedRunnerPaneName*
+
+3.15 g:VtrCreatedRunnerPaneName
+
+When runner panes are created this name will be set on them using:
+"select-pane -T g:VtrCreatedRunnerPaneName"
+
+  let g:VtrCreatedRunnerPaneName = "the name you want"
+
+Default: VTR_Created_Pane
+
+------------------------------------------------------------------------------
+                                                   *VtrAutomaticReattachByName*
+
+3.16 g:VtrAutomaticReattachByName
+
+With this option a search for a runner pane with the name stored in
+g:VtrCreatedRunnerPaneName will be performed and the command will be sent to
+that pane if it exists before any new runner panes are created. defined by
+g:VtrCreatedRunnerPaneName.
+
+  let g:VtrAutomaticReattachByName = 1
 
 Default: 0
 

--- a/plugin/vim-tmux-runner.vim
+++ b/plugin/vim-tmux-runner.vim
@@ -422,16 +422,14 @@ endfunction
 function! s:EnsureRunnerPane(...)
     if exists('s:detached_window')
         call s:ReattachPane()
-    elseif exists('s:runner_pane')
-        return
-    endif
-
-    if g:VtrAutomaticReattachByName == 1
+    elseif g:VtrAutomaticReattachByName == 1
         let found = s:PaneNumberForName(g:VtrCreatedRunnerPaneName)
         if found >= 0
             call s:AttachToSpecifiedPane(found)
             return
         endif
+    elseif exists('s:runner_pane')
+        return
     endif
 
     if exists('a:1')

--- a/plugin/vim-tmux-runner.vim
+++ b/plugin/vim-tmux-runner.vim
@@ -432,7 +432,6 @@ function! s:EnsureRunnerPane(...)
         if found >= 0
             call s:AttachToSpecifiedPane(found)
             return
-
         endif
     endif
 

--- a/plugin/vim-tmux-runner.vim
+++ b/plugin/vim-tmux-runner.vim
@@ -135,9 +135,8 @@ function! s:TmuxPanesByName()
     let lines = split(panes, '\n')
     let result = {}
     for line in lines
-        echo line
-        let matches = matchlist(line, "\vname:(.*),id:(.*)")
-        if len(matches) == 3
+        let matches = matchlist(line, '\vname:(.*),id:(.*)')
+        if len(matches) >= 3
             let name = matches[1]
             let id = matches[2]
             let result[name] = id
@@ -277,7 +276,7 @@ endfunction
 function! s:PaneNumberForName(name)
   let mapped = s:TmuxPanesByName()
   if has_key(mapped, a:name)
-      return mapped[name]
+      return mapped[a:name]
   endif
   return -1
 endfunction
@@ -427,7 +426,7 @@ function! s:EnsureRunnerPane(...)
         return
     endif
 
-    if g:VtrAutomaticReattachByName
+    if g:VtrAutomaticReattachByName == 1
         let found = s:PaneNumberForName(g:VtrCreatedRunnerPaneName)
         if found >= 0
             call s:AttachToSpecifiedPane(found)
@@ -441,7 +440,7 @@ function! s:EnsureRunnerPane(...)
         call s:CreateRunnerPane()
     endif
 
-    endfunction
+endfunction
 
 function! s:SendLinesToRunner(ensure_pane) range
     if a:ensure_pane | call s:EnsureRunnerPane() | endif
@@ -564,11 +563,6 @@ function! s:InitializeVariables()
     call s:InitVariable("g:VtrAppendNewline", 0)
     let s:vtr_percentage = g:VtrPercentage
     let s:vtr_orientation = g:VtrOrientation
-
-    if !exists('g:VtrAutomaticReattachByName')
-        let g:VtrAutomaticReattachByName = 0
-    endif
-
 endfunction
 
 call s:InitializeVariables()

--- a/plugin/vim-tmux-runner.vim
+++ b/plugin/vim-tmux-runner.vim
@@ -562,9 +562,13 @@ function! s:InitializeVariables()
     call s:InitVariable("g:VtrStripLeadingWhitespace", 1)
     call s:InitVariable("g:VtrClearEmptyLines", 1)
     call s:InitVariable("g:VtrAppendNewline", 0)
-    call s:InitVariable("g:VtrAutomaticReattachByName", 0)
     let s:vtr_percentage = g:VtrPercentage
     let s:vtr_orientation = g:VtrOrientation
+
+    if !exists('g:VtrAutomaticReattachByName')
+        let g:VtrAutomaticReattachByName = 0
+    endif
+
 endfunction
 
 call s:InitializeVariables()


### PR DESCRIPTION
This might be very specific to my usage of this project but I often end up in a state with a detached runner when sending commands from another plugin using `VtrSendCommandToRunner!`. I thought I'd put this PR up in case this is a problem other people run in to as well. 

With my usage of this plugin I want all of my commands to go to the same runner command. I created an option that makes that happen, g:VtrAutomaticReattachByName. 

The changes are: 
- Add config option: g: VtrAutomaticReattachByName which will automatically reattach to a pane with the named defined by g: VtrCreatedRunnerPaneName if it exists
- Add config option g: VtrCreatedRunnerPaneName which lets users configure the name used when creating panes
- Add a function to get a map of the pane names to pane ids
- Add an extra arg to AttachToSpecifiedPane which defines whether anything should be printed when the attach is successful
  - For the code I wrote it's not necessary or desired to have the status echo
