### PR TITLE
fix: s:CreateRunnerPane in tmux 3.4.

### DIFF
--- a/plugin/vim-tmux-runner.vim
+++ b/plugin/vim-tmux-runner.vim
@@ -22,7 +22,7 @@ function! s:CreateRunnerPane(...)
         let g:VtrInitialCommand = s:DictFetch(a:1, 'cmd', g:VtrInitialCommand)
     endif
     let s:vim_pane = s:ActivePaneIndex()
-    let cmd = join(["split-window -p", s:vtr_percentage, "-".s:vtr_orientation])
+    let cmd = join(["split-window -l", s:vtr_percentage, "-".s:vtr_orientation])
     call s:SendTmuxCommand(cmd)
     call s:SendTmuxCommand('select-pane -T '.g:VtrCreatedRunnerPaneName)
     let s:runner_pane = s:ActivePaneIndex()


### PR DESCRIPTION
Change split-window -p to split-window -l